### PR TITLE
'status' should only list items in plists

### DIFF
--- a/lib/lunchy.rb
+++ b/lib/lunchy.rb
@@ -35,6 +35,10 @@ class Lunchy
   def status(params)
     pattern = params[0]
     cmd = "launchctl list"
+    if !verbose?
+      agents = "(" + plists.keys.join("|") + ")"
+      cmd << " | grep -i -E \"#{agents}\""
+    end
     cmd << " | grep -i \"#{pattern}\"" if pattern
     execute(cmd)
   end


### PR DESCRIPTION
As all other commands are working with `plists`, the `status` command should also only list items of `/Library/LaunchAgents` and `~/Library/LaunchAgents` as default setting.

Running `lunchy status --verbose` shows the complete listing.
