### PR TITLE
Escape '.' in status regex; seems to fix "Regular expression too big" err

### DIFF
--- a/lib/lunchy.rb
+++ b/lib/lunchy.rb
@@ -45,6 +45,7 @@ class Lunchy
       agents = "(" + plists.keys.join("|") + ")"
       cmd << " | grep -i -E \"#{agents}\""
     end
+    cmd.gsub!('.','\.')
     cmd << " | grep -i \"#{pattern}\"" if pattern
     execute(cmd)
   end


### PR DESCRIPTION
Escape '.' in status regex; seems to fix "Regular expression too big" errors on Lion.

I tried installing a new grep (via homebrew) and that didn't seem to work.

Great little project.
