### PR TITLE
Fixes #13 "grep: Regular expression too big"

### DIFF
--- a/lib/lunchy.rb
+++ b/lib/lunchy.rb
@@ -42,8 +42,8 @@ class Lunchy
     pattern = params[0]
     cmd = "launchctl list"
     if !verbose?
-      agents = "(" + plists.keys.join("|") + ")"
-      cmd << " | grep -i -E \"#{agents}\""
+      agents = plists.keys.map { |k| "-e \"#{k}\"" }.join(" ")
+      cmd << " | grep -i #{agents}"
     end
     cmd.gsub!('.','\.')
     cmd << " | grep -i \"#{pattern}\"" if pattern


### PR DESCRIPTION
I'm using a different strategy for compiling the grep command string that avoids the issue.
