### PR TITLE
Allow to force start disabled agents

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,8 +1,13 @@
 Changes
 ================
 
-0.5.0
+HEAD
 ----
+
+- Allow to force start disabled agents (koraktor)
+
+0.5.0
+-----
 
 - Add default output to start and stop (joncooper)
 - Add 'edit' command to edit the matching plist file (AndreyChernyh)

--- a/bin/lunchy
+++ b/bin/lunchy
@@ -10,6 +10,10 @@ OPERATIONS = %w(start stop restart ls list status install edit)
 option_parser = OptionParser.new do |opts|
   opts.banner = "Lunchy #{Lunchy::VERSION}, the friendly launchctl wrapper\nUsage: #{__FILE__} [#{OPERATIONS.join('|')}] [options]"
 
+  opts.on("-F", "--force", "Force start (disabled) agents") do |verbose|
+    CONFIG[:force] = true
+  end
+
   opts.on("-v", "--verbose", "Show command executions") do |verbose|
     CONFIG[:verbose] = true
   end
@@ -22,14 +26,14 @@ option_parser = OptionParser.new do |opts|
 
 Supported commands:
 
- ls [pattern]           Show the list of installed agents, with optional [pattern] filter
- list [pattern]         Alias for 'ls'
- start [-w] [pattern]   Start the first agent matching [pattern]
- stop [-w] [pattern]    Stop the first agent matching [pattern]
- restart [pattern]      Stop and start the first agent matching [pattern]
- status [pattern]       Show the PID and label for all agents, with optional [pattern] filter
- install [file]         Installs [file] to ~/Library/LaunchAgents or /Library/LaunchAgents (whichever it finds first)
- edit [pattern]         Opens the launchctl daemon file in the default editor (EDITOR environment variable)
+ ls [pattern]            Show the list of installed agents, with optional [pattern] filter
+ list [pattern]          Alias for 'ls'
+ start [-wF] [pattern]   Start the first agent matching [pattern]
+ stop [-w] [pattern]     Stop the first agent matching [pattern]
+ restart [pattern]       Stop and start the first agent matching [pattern]
+ status [pattern]        Show the PID and label for all agents, with optional [pattern] filter
+ install [file]          Installs [file] to ~/Library/LaunchAgents or /Library/LaunchAgents (whichever it finds first)
+ edit [pattern]          Opens the launchctl daemon file in the default editor (EDITOR environment variable)
 
 -w will persist the start/stop command so the agent will load on startup or never load, respectively.
 

--- a/lib/lunchy.rb
+++ b/lib/lunchy.rb
@@ -4,7 +4,7 @@ class Lunchy
   VERSION = '0.5.0'
 
   def start(params)
-    raise ArgumentError, "start [-w] [name]" if params.empty?
+    raise ArgumentError, "start [-wF] [name]" if params.empty?
     name = params[0]
     files = plists.select {|k,v| k =~ /#{name}/i }
     files = Hash[files] if files.is_a?(Array) # ruby 1.8
@@ -13,7 +13,7 @@ class Lunchy
     elsif files.size == 0
       return puts "No daemon found matching '#{name}'" if !name
     else
-      execute("launchctl load #{CONFIG[:write] ? '-w ' : ''}#{files.values.first.inspect}")
+      execute("launchctl load #{CONFIG[:force] ? '-F ' : ''}#{CONFIG[:write] ? '-w ' : ''}#{files.values.first.inspect}")
       puts "started #{files.keys.first}"
     end
   end


### PR DESCRIPTION
I usually have several agents I just use for special purposes (like testing web applications) so they are disabled by default. Using the current version of lunchy you're unable to launch such agents because `launchctl` will refuse to load them with `nothing found to load`.

This patch will add a new option `-F`/`--force` to the `start` command that will be passed as `-F` to `launchctl` and therefore will allow to start disabled agents.
