### PR TITLE
Add ability to match exact agent/service name

### DIFF
--- a/bin/lunchy
+++ b/bin/lunchy
@@ -11,6 +11,10 @@ option_parser = OptionParser.new do |opts|
   opts.banner = "Lunchy #{Lunchy::VERSION}, the friendly launchctl wrapper\n" \
     "Usage: #{File.basename(__FILE__)} [#{OPERATIONS.join('|')}] [options]"
 
+  opts.on("-x", "--exact", "Force exact (case insensitive) match when specifying a [pattern]") do
+    CONFIG[:exact] = true
+  end
+
   opts.on("-F", "--force", "Force start (disabled) agents") do |verbose|
     CONFIG[:force] = true
   end
@@ -48,6 +52,7 @@ Supported commands:
 
 -w will persist the start/stop command so the agent will load on startup or never load, respectively.
 -l will display absolute paths of the launchctl daemon files when showing list of installed agents.
+-x will force exact matching of the [pattern] for any command that uses a pattern
 
 Example:
  lunchy ls
@@ -58,6 +63,7 @@ Example:
  lunchy install /usr/local/Cellar/redis/2.2.2/io.redis.redis-server.plist
  lunchy show redis
  lunchy edit mongo
+ lunchy uninstall -x elasticsearch # will not try to uninstall elasticsearch14
 
 Note: if you run lunchy as root, you can manage daemons in /Library/LaunchDaemons also.
 EOS


### PR DESCRIPTION
* new -x option to match exactly
* mods to grep and with_match usages to use an exact pattern if -x is set on the command line
* fixed issue in `with_match` which was not sending the 'no daemon' message (if instead of unless)

Without this fix, on a system with homebrew's elasticsearch and elasticsearch14,
you can't `lunchy uninstall` or `lunchy start` because `homebrew.mxcl.elasticsearch` is
a match for both.

After this you can

`lunchy stop -x homebrew.mxcl.elasticsearch`

Note:  I left VERSION alone, though I think it'll need a bump before a release.