### PR TITLE
Add autocomplete script to the gem

### DIFF
--- a/extras/lunchy-completion.bash
+++ b/extras/lunchy-completion.bash
@@ -1,0 +1,18 @@
+###
+# completion written by Alexey Shockov
+# on github : alexeyshockov
+#
+function _lunchy {
+  COMPREPLY=()
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local cur_pos=$COMP_CWORD;
+
+  case "$cur_pos" in
+    1) COMPREPLY=($(compgen -W 'ls list start stop restart status install uninstall show edit' -- $cur))
+       ;;
+    *) COMPREPLY=($(compgen -W '$(lunchy list)' -- $cur))
+       ;;
+  esac
+}
+
+complete -F _lunchy -o default lunchy

--- a/lunchy.gemspec
+++ b/lunchy.gemspec
@@ -1,6 +1,22 @@
 # -*- encoding: utf-8 -*-
 require "./lib/lunchy"
 
+post_install_message = <<-EOS
+-------
+
+Thanks for installing Lunchy.  We know you're going to love it!
+
+If you want to add tab-completion (for bash), add the following 
+to your .bash_profile, .bashrc or .profile
+
+   LUNCHY_DIR=$(dirname `gem which lunchy`)/../extras
+   if [ -f $LUNCH_DIR/lunchy-completion.bash ]; then
+     . $LUNCHY_DIR/lunchy-completion.bash
+   fi
+
+-------
+EOS
+
 Gem::Specification.new do |s|
   s.name        = "lunchy"
   s.version     = Lunchy::VERSION
@@ -9,6 +25,7 @@ Gem::Specification.new do |s|
   s.email       = ["mperham@gmail.com"]
   s.homepage    = "http://github.com/mperham/lunchy"
   s.summary     = s.description = %q{Friendly wrapper around launchctl}
+  s.post_install_message = post_install_message
   s.licenses    = ['MIT']
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Attempt to address #46 

* add post install message
* add autocomplete script from @alexeyshockov


I tried this build locally and added it looks good.  The place it gets a little weird is when you switch projects and `rbenv` (or `rvm`) doesn't have `lunchy` installed in that gemset.  Or if you move to a project directory (with a ruby version manager) that has an older version of `lunchy`.  At that point, the `gem which lunchy` will return a path that points to the old version and the completion is not available.

I don't know if that warrants installation instructions (like put this in your system gem set) or if it just rights itself over time because overtime, if you have multiple versions of `lunchy` installed, they'll all have the bash completion and things will just work.
