### PR TITLE
fixed sloppy environment var in post install message

### DIFF
--- a/lunchy.gemspec
+++ b/lunchy.gemspec
@@ -10,7 +10,7 @@ If you want to add tab-completion (for bash), add the following
 to your .bash_profile, .bashrc or .profile
 
    LUNCHY_DIR=$(dirname `gem which lunchy`)/../extras
-   if [ -f $LUNCH_DIR/lunchy-completion.bash ]; then
+   if [ -f $LUNCHY_DIR/lunchy-completion.bash ]; then
      . $LUNCHY_DIR/lunchy-completion.bash
    fi
 


### PR DESCRIPTION
Sorry.

I just followed the post install message and realized there was a typo in the messaging.

quick fix to the typo.