### PR TITLE
add output to status

### DIFF
--- a/lib/lunchy.rb
+++ b/lib/lunchy.rb
@@ -36,6 +36,7 @@ class Lunchy
 
     cmd.gsub!('.','\.')
     cmd << " | grep -i \"#{pattern}\"" if pattern
+    print "PID\tStatus\tLabel\n"
     execute(cmd)
   end
 


### PR DESCRIPTION
I think it is better to match output of `lunchy status` with that of `launchctl list` more precisely.  
I added `PID  Status  Label` in the first line of the output.

Before：
```
> lunchy status
9477	0	com.danga.memcached
48499	0	com.google.keystone.agent
-		1	com.mysql.mysqld
-		1	io.redis.redis-server
411		0	org.mongodb.mongod
```

After：
```
> lunchy status
PID		Status	Label
9477	0	com.danga.memcached
48499	0	com.google.keystone.agent
-		1	com.mysql.mysqld
-		1	io.redis.redis-server
411		0	org.mongodb.mongod
```


