### PR TITLE
Added -U flag to autoload

### DIFF
--- a/extras/lunchy-completion.zsh
+++ b/extras/lunchy-completion.zsh
@@ -3,6 +3,6 @@
 # on github : osaris
 #
 
-autoload bashcompinit
+autoload -U bashcompinit
 bashcompinit
 source $(dirname $0)/lunchy-completion.bash


### PR DESCRIPTION
This is for #66 .

For the zsh experts out there, I hope the -U flag can be explained. From what I understand, you need the -U to ensure that the function you're calling corresponds to a file with that filename somewhere in your bin path?